### PR TITLE
Allowing sending of parameter in the getPayment

### DIFF
--- a/src/Fakturownia.php
+++ b/src/Fakturownia.php
@@ -789,17 +789,15 @@ class Fakturownia
      * Get payment
      *
      * @param int $id Payment ID
-     *
+     * @param array $params
      * @return ResponseInterface
      *
      * @throws Exception\RequestErrorException
      */
-    public function getPayment(int $id): ResponseInterface
+    public function getPayment(int $id, array $params = []): ResponseInterface
     {
         $url = $this->baseUrl . '/banking/payments/' . $id . '.json';
-        $params = [
-            'api_token' => $this->apiToken,
-        ];
+        $params['api_token'] = $this->apiToken;
 
         return $this->restClient->get($url, $params);
     }


### PR DESCRIPTION
Allowing to send of parameters when getting a payment info, in connection with the possibility of downloading information on invoices connected with payment, by passing parameter: include=invoices